### PR TITLE
Fix exception when parsing with sliced Data

### DIFF
--- a/Sources/CBORCoding/CBORParser.swift
+++ b/Sources/CBORCoding/CBORParser.swift
@@ -20,10 +20,10 @@ internal class CBORParser {
         guard !data.isEmpty else { return nil }
 
         var storage = Storage()
-        var index: Int = 0
+        var index: Int = data.startIndex
 
         do {
-            while index < data.count {
+            while index < data.endIndex {
                 let majorType = CBOR.majorType(for: data[index])
 
                 switch majorType {

--- a/Tests/CBORCodingTests/CBORParserTests.swift
+++ b/Tests/CBORCodingTests/CBORParserTests.swift
@@ -22,7 +22,7 @@ class CBORParserTests: XCTestCase {
         // Test Examples taken from Appendix A of RFC 7049
 
         var value: Any!
-
+        
         XCTAssertNoThrow(value = try CBORParser.parse(convertFromHexString("0x00")))
         XCTAssertTrue(value is UInt64)
         XCTAssertEqual(value as! UInt64, 0)
@@ -1074,6 +1074,18 @@ class CBORParserTests: XCTestCase {
         #endif // #if arch(arm64) || arch(x86_64)
 
         XCTAssertThrowsError(try CBORParser.testCreateCodingKey(from: UInt64.max))
+    }
+    
+    func testSlicedDataInput() {
+        var value: Any!
+        
+        // Skip over the first 2 bytes with a slice.
+        let data = convertFromHexString("0x000000")[2...]
+        
+        XCTAssertNoThrow(value = try CBORParser.parse(data))
+        XCTAssertTrue(value is UInt64)
+        XCTAssertEqual(value as! UInt64, 0)
+
     }
 
     // MARK: Private Methods


### PR DESCRIPTION
When a Data input is used that has a slice started beyond 0, an exception was thrown because the parser tried to access index 0.

See for example https://stackoverflow.com/questions/54698947/swift-data-subdata-fails-with-exc-bad-instruction-code-exc-i386-invop-subcode for an explanation.

All that was needed to fix it was to start at `data.startIndex` and finishes before `data.endIndex`.
I also added a testcase that failed before my change and succeeds after my changes. The rest of the cases still run.