### PR TITLE
Make sure failures in multiline CI steps are not swallowed.

### DIFF
--- a/.github/CONTRIBUTORS.md
+++ b/.github/CONTRIBUTORS.md
@@ -5,6 +5,7 @@
 I would like to give a special thanks to all of the people below who have contributed to this project and to all of those who will contribute to it moving forward.
 
 - [Jos Kuijpers](https://github.com/joskuijpers)
+- [Dave Abrahams](https://github.com/dabrahams)
 
 ## I would like to join this list! How can I help the project?
 

--- a/.github/workflows/carthage.yml
+++ b/.github/workflows/carthage.yml
@@ -1,4 +1,7 @@
 name: Carthage
+defaults:
+  run:
+    shell: bash -eo pipefail {0}
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -1,4 +1,7 @@
 name: Cocoapods
+defaults:
+  run:
+    shell: bash -eo pipefail {0}
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,4 +1,7 @@
 name: Documentation
+defaults:
+  run:
+    shell: bash -eo pipefail {0}
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/publish-cocoapods.yml
+++ b/.github/workflows/publish-cocoapods.yml
@@ -1,4 +1,7 @@
 name: Publish CocoaPods
+defaults:
+  run:
+    shell: bash -eo pipefail {0}
 on:
   release:
     types: [published]

--- a/.github/workflows/swift-package.yml
+++ b/.github/workflows/swift-package.yml
@@ -1,4 +1,7 @@
 name: Swift Package
+defaults:
+  run:
+    shell: bash -eo pipefail {0}
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,4 +1,7 @@
 name: SwiftLint
+defaults:
+  run:
+    shell: bash -eo pipefail {0}
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -1,4 +1,7 @@
 name: Upload Assets
+defaults:
+  run:
+    shell: bash -eo pipefail {0}
 on:
   release:
     types: [published]

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -1,4 +1,7 @@
 name: XCFramework
+defaults:
+  run:
+    shell: bash -eo pipefail {0}
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -1,4 +1,7 @@
 name: Xcode Project
+defaults:
+  run:
+    shell: bash -eo pipefail {0}
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
## Description

Cause failures in CI to be reported

## Checklist

Ensure that your `pull request` has followed all the steps below:

* [x] Code compilation.
* [x] All tests passing.
* [x] No new SwiftLint issues.
* [x] Added new unit tests, if applicable.
* [x] Extended the documentation (including README), if applicable.
* [x] Updated version in CBORCoding.podspec following [semver](https://semver.org) guidelines.
* [x] Ran [workflowtests.sh](../../scripts/workflowtests.sh) and passed.
* [x] Added myself to the [CONTRIBUTORS](../CONTRIBUTORS.md) file.

## Proposed changes

Without this change, it is possible to have a passing CI job even though the build failed, e.g.

https://github.com/dabrahams/CBORCoding/actions/runs/6806944368/job/18509010389#step:4:99

And in fact you will see that this PR reveals [1 linting problem](https://github.com/dabrahams/CBORCoding/actions/runs/6816579160/job/18538199288#step:5:12064) and [11 test failures on ubuntu-latest](https://github.com/dabrahams/CBORCoding/actions/runs/6816579161/job/18538228434) that were being ignored.  